### PR TITLE
LIBS-553 - Restore repository sonar-oss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,13 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>sonatype-oss</id>
+      <url>https://oss.sonatype.org/content/repositories/releases</url>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <!-- BUILD AND FILES -->


### PR DESCRIPTION
To improve maven deployment the repository with id `sonar-oss` is restored.